### PR TITLE
Declare required providers for Gatekeeper modules

### DIFF
--- a/regional/constraints/providers.tofu
+++ b/regional/constraints/providers.tofu
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/regional/providers.tofu
+++ b/regional/providers.tofu
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+
+    # Helm Provider
+    # https://search.opentofu.org/provider/hashicorp/helm/latest/docs
+
+    helm = {
+      source = "hashicorp/helm"
+    }
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/regional/templates/providers.tofu
+++ b/regional/templates/providers.tofu
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
## What
- Add minimal required_providers declarations for the regional Gatekeeper module and its constraints/templates submodules.
- Declare helm only where helm_release is used and kubernetes where kubernetes_manifest resources are used.

## Why
Consumers such as pt-pneuma pass explicit per-cluster provider instances through providers maps. Declaring required_providers prevents OpenTofu undefined-provider warnings while keeping child modules free of provider configuration blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added and updated infrastructure configuration to declare required providers for Kubernetes and Helm across regional environments.
  * This helps ensure the correct provider versions are available when managing regional deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->