### PR TITLE
Deduplicate providers.tofu across constraints and templates using shared symlink

### DIFF
--- a/regional/constraints/providers.tofu
+++ b/regional/constraints/providers.tofu
@@ -1,11 +1,1 @@
-terraform {
-  required_providers {
-
-    # Kubernetes Provider
-    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
-
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-    }
-  }
-}
+../shared/providers.tofu

--- a/regional/shared/providers.tofu
+++ b/regional/shared/providers.tofu
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+
+    # Kubernetes Provider
+    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
+
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
+}

--- a/regional/templates/providers.tofu
+++ b/regional/templates/providers.tofu
@@ -1,11 +1,1 @@
-terraform {
-  required_providers {
-
-    # Kubernetes Provider
-    # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs
-
-    kubernetes = {
-      source = "hashicorp/kubernetes"
-    }
-  }
-}
+../shared/providers.tofu


### PR DESCRIPTION
`regional/constraints/providers.tofu` and `regional/templates/providers.tofu` were byte-for-byte identical (kubernetes provider only). Moved the canonical copy to `regional/shared/providers.tofu` and replaced both with relative symlinks, following the `shared/helpers.tofu` pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Standardized infrastructure provider configuration for regional shared resources.
  - Removed redundant provider declarations from regional constraints and templates.
  - No direct user-facing feature or behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->