### PR TITLE
Update OPA Gatekeeper to v3.23.0

### DIFF
--- a/regional/variables.tofu
+++ b/regional/variables.tofu
@@ -84,7 +84,7 @@ variable "controller_manager_resources_requests_memory" {
 variable "gatekeeper_version" {
   description = "The version to install, this is used for the chart as well as the image tag"
   type        = string
-  default     = "v3.22.0"
+  default     = "v3.23.0"
 }
 
 variable "node_location" {


### PR DESCRIPTION
Update upstream component versions:
- `gatekeeper_version`: v3.22.0 → v3.23.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Gatekeeper version to 3.23.0 for deployments that do not specify a version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->