### PR TITLE
Add K8sProtectGatewayAuth guardrail constraint and template

### DIFF
--- a/regional/constraints/main.tofu
+++ b/regional/constraints/main.tofu
@@ -26,3 +26,35 @@ resource "kubernetes_manifest" "block_ingress_constraint" {
     }
   }
 }
+
+resource "kubernetes_manifest" "protect_gateway_auth_constraint" {
+  manifest = {
+    apiVersion = "constraints.gatekeeper.sh/v1beta1"
+    kind       = "K8sProtectGatewayAuth"
+
+    metadata = {
+      name = "protect-gateway-auth"
+    }
+
+    spec = {
+      enforcementAction = "deny"
+
+      match = {
+        kinds = [
+          {
+            apiGroups = [""]
+            kinds     = ["Namespace", "Secret"]
+          },
+          {
+            apiGroups = ["networking.istio.io"]
+            kinds     = ["EnvoyFilter"]
+          },
+          {
+            apiGroups = ["security.istio.io"]
+            kinds     = ["AuthorizationPolicy", "RequestAuthentication"]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth.rego
+++ b/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth.rego
@@ -1,0 +1,38 @@
+package k8sprotectgatewayauth
+
+# Platform break-glass group permitted to manage gateway authn/authz resources.
+allowed_principal if {
+	"system:masters" in input.review.userInfo.groups
+}
+
+# Istio authn/authz resources that only platform principals may manage.
+protected_kinds := {
+	{"group": "networking.istio.io", "kind": "EnvoyFilter"},
+	{"group": "security.istio.io", "kind": "AuthorizationPolicy"},
+	{"group": "security.istio.io", "kind": "RequestAuthentication"},
+}
+
+# Namespaces whose lifecycle and Secrets are platform-managed.
+protected_namespaces := {"keycloak", "oauth2-proxy"}
+
+review_object := object.get(input.review, "object", object.get(input.review, "oldObject", {}))
+
+violation contains {"msg": msg} if {
+	not allowed_principal
+	{"group": input.review.kind.group, "kind": input.review.kind.kind} in protected_kinds
+	msg := sprintf("gateway authn/authz resource %s/%s is platform-managed and may only be changed by platform principals", [input.review.kind.group, input.review.kind.kind])
+}
+
+violation contains {"msg": msg} if {
+	not allowed_principal
+	input.review.kind.kind == "Namespace"
+	review_object.metadata.name in protected_namespaces
+	msg := sprintf("namespace %q is platform-managed and may only be changed by platform principals", [review_object.metadata.name])
+}
+
+violation contains {"msg": msg} if {
+	not allowed_principal
+	input.review.kind.kind == "Secret"
+	object.get(review_object.metadata, "namespace", "") in protected_namespaces
+	msg := sprintf("secrets in platform-managed namespace %q may only be changed by platform principals", [object.get(review_object.metadata, "namespace", "")])
+}

--- a/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth.rego
+++ b/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth.rego
@@ -13,7 +13,7 @@ protected_kinds := {
 }
 
 # Namespaces whose lifecycle and Secrets are platform-managed.
-protected_namespaces := {"keycloak", "oauth2-proxy"}
+protected_namespaces := {"authentik"}
 
 review_object := object.get(input.review, "object", object.get(input.review, "oldObject", {}))
 

--- a/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth.rego
+++ b/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth.rego
@@ -5,6 +5,13 @@ allowed_principal if {
 	"system:masters" in input.review.userInfo.groups
 }
 
+# Gatekeeper audit reviews carry no userInfo (there is no requesting actor), so the identity of the
+# change cannot be evaluated. Treat those reviews as allowed to avoid reporting every pre-existing
+# protected resource as a false-positive violation; admission requests always populate userInfo.
+allowed_principal if {
+	not input.review.userInfo
+}
+
 # Istio authn/authz resources that only platform principals may manage.
 protected_kinds := {
 	{"group": "networking.istio.io", "kind": "EnvoyFilter"},

--- a/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth_test.rego
+++ b/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth_test.rego
@@ -22,19 +22,19 @@ test_platform_principal_allowed if {
 test_protected_namespace_denied if {
 	some result in k8sprotectgatewayauth.violation with input as {"review": {
 		"kind": {"group": "", "kind": "Namespace"},
-		"object": {"metadata": {"name": "keycloak"}},
+		"object": {"metadata": {"name": "authentik"}},
 		"userInfo": {"groups": ["system:authenticated"]},
 	}}
-	result.msg == "namespace \"keycloak\" is platform-managed and may only be changed by platform principals"
+	result.msg == "namespace \"authentik\" is platform-managed and may only be changed by platform principals"
 }
 
 test_protected_secret_denied if {
 	some result in k8sprotectgatewayauth.violation with input as {"review": {
 		"kind": {"group": "", "kind": "Secret"},
-		"object": {"metadata": {"name": "oidc", "namespace": "oauth2-proxy"}},
+		"object": {"metadata": {"name": "oidc", "namespace": "authentik"}},
 		"userInfo": {"groups": ["system:authenticated"]},
 	}}
-	result.msg == "secrets in platform-managed namespace \"oauth2-proxy\" may only be changed by platform principals"
+	result.msg == "secrets in platform-managed namespace \"authentik\" may only be changed by platform principals"
 }
 
 test_unprotected_kind_allowed if {

--- a/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth_test.rego
+++ b/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth_test.rego
@@ -1,0 +1,46 @@
+package k8sprotectgatewayauth_test
+
+import data.k8sprotectgatewayauth
+
+test_protected_istio_kind_denied if {
+	some result in k8sprotectgatewayauth.violation with input as {"review": {
+		"kind": {"group": "security.istio.io", "kind": "AuthorizationPolicy"},
+		"object": {"metadata": {"name": "deny-all"}},
+		"userInfo": {"groups": ["system:authenticated"]},
+	}}
+	result.msg == "gateway authn/authz resource security.istio.io/AuthorizationPolicy is platform-managed and may only be changed by platform principals"
+}
+
+test_platform_principal_allowed if {
+	count(k8sprotectgatewayauth.violation) == 0 with input as {"review": {
+		"kind": {"group": "security.istio.io", "kind": "AuthorizationPolicy"},
+		"object": {"metadata": {"name": "deny-all"}},
+		"userInfo": {"groups": ["system:masters"]},
+	}}
+}
+
+test_protected_namespace_denied if {
+	some result in k8sprotectgatewayauth.violation with input as {"review": {
+		"kind": {"group": "", "kind": "Namespace"},
+		"object": {"metadata": {"name": "keycloak"}},
+		"userInfo": {"groups": ["system:authenticated"]},
+	}}
+	result.msg == "namespace \"keycloak\" is platform-managed and may only be changed by platform principals"
+}
+
+test_protected_secret_denied if {
+	some result in k8sprotectgatewayauth.violation with input as {"review": {
+		"kind": {"group": "", "kind": "Secret"},
+		"object": {"metadata": {"name": "oidc", "namespace": "oauth2-proxy"}},
+		"userInfo": {"groups": ["system:authenticated"]},
+	}}
+	result.msg == "secrets in platform-managed namespace \"oauth2-proxy\" may only be changed by platform principals"
+}
+
+test_unprotected_kind_allowed if {
+	count(k8sprotectgatewayauth.violation) == 0 with input as {"review": {
+		"kind": {"group": "apps", "kind": "Deployment"},
+		"object": {"metadata": {"name": "web", "namespace": "team-a"}},
+		"userInfo": {"groups": ["system:authenticated"]},
+	}}
+}

--- a/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth_test.rego
+++ b/regional/templates/k8sprotectgatewayauth/k8sprotectgatewayauth_test.rego
@@ -44,3 +44,12 @@ test_unprotected_kind_allowed if {
 		"userInfo": {"groups": ["system:authenticated"]},
 	}}
 }
+
+# Audit reviews have no userInfo, so identity cannot be evaluated; existing protected resources
+# must not be reported as violations.
+test_audit_review_without_user_info_allowed if {
+	count(k8sprotectgatewayauth.violation) == 0 with input as {"review": {
+		"kind": {"group": "security.istio.io", "kind": "AuthorizationPolicy"},
+		"object": {"metadata": {"name": "deny-all"}},
+	}}
+}

--- a/regional/templates/main.tofu
+++ b/regional/templates/main.tofu
@@ -38,3 +38,41 @@ resource "kubernetes_manifest" "block_ingress_constraint_template" {
     }
   }
 }
+
+resource "kubernetes_manifest" "protect_gateway_auth_constraint_template" {
+  manifest = {
+    apiVersion = "templates.gatekeeper.sh/v1"
+    kind       = "ConstraintTemplate"
+
+    metadata = {
+      name = "k8sprotectgatewayauth"
+    }
+
+    spec = {
+      crd = {
+        spec = {
+          names = {
+            kind = "K8sProtectGatewayAuth"
+          }
+        }
+      }
+
+      targets = [
+        {
+          target = "admission.k8s.gatekeeper.sh"
+
+          code = [
+            {
+              engine = "Rego"
+
+              source = {
+                version = "v1"
+                rego    = file("${path.module}/k8sprotectgatewayauth/k8sprotectgatewayauth.rego")
+              }
+            }
+          ]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Adds a static Gatekeeper `ConstraintTemplate` (`K8sProtectGatewayAuth`) and its `Constraint` (`protect-gateway-auth`), modeled after the existing `block_ingress` constraint.

## What it does

Denies mutations to platform-managed gateway authn/authz resources unless the actor is in the `system:masters` break-glass group:

- Istio `RequestAuthentication`, `AuthorizationPolicy` (security.istio.io) and `EnvoyFilter` (networking.istio.io)
- The `keycloak` and `oauth2-proxy` namespaces and Secrets within them

## Notes

- Fully static, following the `block_ingress` pattern (no module inputs).
- Includes rego unit tests (`opa test`, 5/5 passing) alongside the template.
- Part of osinfra-io/pt-pneuma#142 (RBAC/admission guardrails).

## Rollout

A brand-new constraint can only be *planned* after its `ConstraintTemplate` CRD is applied to the cluster, so the templates workspace must apply before the constraints workspace plans cleanly — the same bootstrap ordering as `block_ingress`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added policy enforcement to protect gateway authentication and authorization resources from unauthorized changes.
  * Restricted modifications to protected namespaces, Secrets, and Istio security resources to approved platform administrators.
  * Added controlled break-glass access for authorized system administrators.
  * Allowed security audit reviews to proceed without requiring end-user identity information.

* **Tests**
  * Added coverage for denied unauthorized changes and permitted platform-managed, audit, or out-of-scope resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->